### PR TITLE
Force TypeScript to version 1.4 until an upgrade is possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "jake": "latest",
-    "typescript": "^1.4",
+    "typescript": "1.4",
     "nw": "^0.12.0",
     "node-webkit-builder": "latest"
   },


### PR DESCRIPTION
This resolves an issue where TouchDevelop wont build.