### PR TITLE
Make the :hover styles more subtle

### DIFF
--- a/www/default.css
+++ b/www/default.css
@@ -491,8 +491,7 @@ p.wall-record
 }
 
 .wall-button:hover {
-  color:white;
-  background:black;
+  background: rgba(100,100,100,0.2);
 }
 
 #theWall .wall-button, #wall-overlay .wall-button /* Windows 8 Modern guidelines */
@@ -812,8 +811,7 @@ div.topButtons button {
 .topMenu-button-frame:hover,
 .tabMenu-button-frame:hover
 {
-  background-color:black;
-  color:white;
+  background: rgba(100,100,100,0.3);
 }
 
 .tabMenu-button-frame {

--- a/www/editor.css
+++ b/www/editor.css
@@ -88,7 +88,7 @@ button.navItem
 }
 
 button.navItem:hover {
-  border-left-color:#E72A59;
+  border-left-color:rgba(100,100,100,0.3);
 }
 
 .navItem
@@ -2806,7 +2806,7 @@ a.md-bigbutton:hover {
 
 .sdHeaderOuter:hover
 {
-  border-left-color:#E72A59;
+  border-left-color:rgba(100,100,100,0.3);
 }
 
 .sdBaseHeader {
@@ -3516,7 +3516,7 @@ div.sdTabTileLabel {
 }
 
 .sdBigButton:hover {
-  border: solid white 0.25em;
+  transform: translate(0.15em, 0.15em);                      /*CSSpref*/  -webkit-transform: translate(0.15em, 0.15em);  -moz-transform: translate(0.15em, 0.15em);  -ms-transform: translate(0.15em, 0.15em);
 }
 
 .phone .sdBigButtonFull {
@@ -4066,7 +4066,7 @@ right:4.5em;
 }
 
 .hubTile:hover {
-  border: solid white 0.1em;
+  transform: translate(0.1em, 0.1em);                      /*CSSpref*/  -webkit-transform: translate(0.1em, 0.1em);  -moz-transform: translate(0.1em, 0.1em);  -ms-transform: translate(0.1em, 0.1em);
 }
 
 .hubTileSize1 {

--- a/www/editor.css
+++ b/www/editor.css
@@ -1,3 +1,7 @@
+* {
+  transition: transform 0.1s, background-color 0.1s;
+}
+
 div.calcButtonHelp {
     font-family: "Segoe UI", "Segoe WP", "Helvetica Neue", Sans-Serif;
 }


### PR DESCRIPTION
@pelikhan - did you follow some specific guidelines when just flipping the colors for the buttons on :hover? 

If not, could we go with a more subtle highlight below?

It also changes the color of red hover bar to be gray, and instead of putting frame around big square buttons it just moves them right-down.