### PR TITLE
Fix truncated change numbers in history list

### DIFF
--- a/editor/scriptList.ts
+++ b/editor/scriptList.ts
@@ -3651,7 +3651,7 @@
                     div("sdHeader",
                         icon,
                         div("sdHeaderInner",
-                            div("sdNameBlock", div("sdName", spanDirAuto(it.scriptname + (it.entryNo === undefined ? "" : " #" + it.entryNo)))),
+                            div("sdNameBlock", div("sdName", spanDirAuto((it.entryNo === undefined ? "" : "#" + it.entryNo + " ") + it.scriptname))),
                             div("sdAddInfoOuter",
                                 div("sdAddInfoInner",
                                     Util.timeSince(it.time)


### PR DESCRIPTION
In the "history" list, the change number (#0, #1, etc.) appears after the script name.  For long-ish script names (like "astonishing Jetpack Jumper"), the name is truncated which removes the change number.  This makes it difficult to navigate the changes, as one might have many changes saying "2 days ago", with the only discernible difference in the history list being different character counts.

This fix moves the change number before the script name, so it is still visible if the name is truncated.

### **Before (screenshot from Chrome running full screen on a 1920x1080 display on Win 7 Prof SP 1):**

![image](https://cloud.githubusercontent.com/assets/437106/11941876/7570ced4-a7e7-11e5-8100-56951794985d.png)

### **After:**


![image](https://cloud.githubusercontent.com/assets/437106/11941898/909f7a98-a7e7-11e5-99d1-dde6080dd16e.png)

