### PR TITLE
Don't add role=button to scriptEditor div

### DIFF
--- a/editor/editor.ts
+++ b/editor/editor.ts
@@ -4473,6 +4473,7 @@ module TDev
             r.style.display = "none";
             elt("root").appendChild(divId("testHostFrame", null));
             elt("root").appendChild(r);
+            elt("scriptEditor").setAttribute("data-norole", "true");
             Util.setupDragToScroll(elt("leftPaneContent"));
         }
 

--- a/rt/utilClick.ts
+++ b/rt/utilClick.ts
@@ -259,7 +259,7 @@ module TDev
         export function clickHandler(e:HTMLElement, cb:(e:any) => void, allowSelect?:boolean)
         {
             if (e) {
-                if (!e.getAttribute("role"))
+                if (!e.getAttribute("role") && !e.getAttribute("data-norole"))
                     e.setAttribute("role", "button")
                 e.tabIndex = 0;
             }


### PR DESCRIPTION
...as this prevents screen readers from using ARIA roles of elements in the external editor iframe. For example any divs with role=alert are not read by the screen reader with this parent as role=button

If there is a more idiomatic way to implement this in TD (without the `data-norole` attribute) please advise @pelikhan 

Thanks,
Andrew