### PR TITLE
Test: Revert runtime version, v82 is broken

### DIFF
--- a/rt/cloud.ts
+++ b/rt/cloud.ts
@@ -277,7 +277,7 @@ module TDev.Cloud {
                 return origin + "/blockly/render.html?id=" + encodeURIComponent(id);
             }
         },
-        microbitGitTag : "v82"
+        microbitGitTag : "v79"
     }
 
     export function isArtUrl(url : string) : boolean {


### PR DESCRIPTION
The current runtime version, v82(--> 1.4.20) changes the DAL
appears to be responsible for connection failures on iOS after
updates.

This problem was not present on v79(1.4.17) so this commit reverts
the DAL version update until we can establish why the iOS problem
exists.