### PR TITLE
Always load script before migrating

### DIFF
--- a/editor/scriptList.ts
+++ b/editor/scriptList.ts
@@ -6159,7 +6159,9 @@ module TDev.Browser {
                  tick(Ticks.browseEditInstall);
                  return TheEditor.prepareForLoadAsync(lf("installing and loading script"),
                      () => TheApiCacheMgr.getAsync(this.publicId, true).then((info: JsonScript) => TheEditor.loadPublicScriptAsync(this.publicId, info.userid)));
-             }
+            } else {
+                 return TheApiCacheMgr.getAsync(this.publicId, true);
+            }
         }
 
         public edit() {
@@ -7461,32 +7463,36 @@ module TDev.Browser {
 
         private migrateToPXT() {
             console.log("Migrating to PXT");
-            this.loadForMigration();
-            return this.internalSaveToJSONAsync(true)
-                .then((json: string) => {
-                    console.log(json);
-                    return lzmaCompressAsync(json)
-                        .then((jsonz: Uint8Array) => {
-                            var buf = Util.base64EncodeBytes(Util.toArray(jsonz));
-                            Util.navigateNewWindow("https://makecode.microbit.org/v0/#project:" + buf);
-                        })
-                });
+            this.loadForMigration()
+            .then(() => {
+                return this.internalSaveToJSONAsync(true)
+                    .then((json: string) => {
+                        console.log(json);
+                        return lzmaCompressAsync(json)
+                            .then((jsonz: Uint8Array) => {
+                                var buf = Util.base64EncodeBytes(Util.toArray(jsonz));
+                                Util.navigateNewWindow("https://makecode.microbit.org/v0/#project:" + buf);
+                            })
+                    });
+            });
         }
 
         private migrateToPythonEditor() {
             console.log("Migrating to Python editor");
-            this.loadForMigration();
-            return this.internalSaveToJSONAsync(true)
-                .then((json: string) => {
-                    return lzmaCompressAsync(json)
-                        .then((jsonz: Uint8Array) => {
-                            console.log(jsonz);
-                            console.log(Util.toArray(jsonz));
-                            var buf = Util.base64EncodeBytes(Util.toArray(jsonz));
-                            Util.navigateNewWindow("https://python.microbit.org/v/1.1#project:" + buf);
-                            console.log(buf);
-                        })
-                });
+            this.loadForMigration()
+            .then(() => {
+                return this.internalSaveToJSONAsync(true)
+                    .then((json: string) => {
+                        return lzmaCompressAsync(json)
+                            .then((jsonz: Uint8Array) => {
+                                console.log(jsonz);
+                                console.log(Util.toArray(jsonz));
+                                var buf = Util.base64EncodeBytes(Util.toArray(jsonz));
+                                Util.navigateNewWindow("https://python.microbit.org/v/1.1#project:" + buf);
+                                console.log(buf);
+                            })
+                    });
+            });
         }
 
         private moderate() {

--- a/editor/scriptList.ts
+++ b/editor/scriptList.ts
@@ -6150,6 +6150,17 @@ module TDev.Browser {
                     TheEditor.loadScriptAsync(this.cloudHeader));
             }
         }
+        
+        public loadForMigration(): Promise {
+             TheEditor.lastListPath = this.browser().getApiPath()
+             if (!this.cloudHeader || this.cloudHeader.status == "deleted") {
+                 if (!this.publicId) return Promise.as(); // hmm?
+                 this.browser().hide();
+                 tick(Ticks.browseEditInstall);
+                 return TheEditor.prepareForLoadAsync(lf("installing and loading script"),
+                     () => TheApiCacheMgr.getAsync(this.publicId, true).then((info: JsonScript) => TheEditor.loadPublicScriptAsync(this.publicId, info.userid)));
+             }
+        }
 
         public edit() {
             this.editAsync().done(
@@ -7449,6 +7460,8 @@ module TDev.Browser {
         }
 
         private migrateToPXT() {
+            console.log("Migrating to PXT");
+            this.loadForMigration();
             return this.internalSaveToJSONAsync(true)
                 .then((json: string) => {
                     console.log(json);
@@ -7461,6 +7474,8 @@ module TDev.Browser {
         }
 
         private migrateToPythonEditor() {
+            console.log("Migrating to Python editor");
+            this.loadForMigration();
             return this.internalSaveToJSONAsync(true)
                 .then((json: string) => {
                     return lzmaCompressAsync(json)


### PR DESCRIPTION
Currently the migrate button does not work if the script hasn't previously been opened in an editor

Example (may have to open in a private session):
https://microbit.co.uk/riotng

This patch ensures that the the script is always loaded before attempting to migrate

@whaleygeek @microbit-matt-hillsdon